### PR TITLE
Support EB hosts (Amazon linux). Related verygood-ops/infra-vault#547

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,4 +2,7 @@
 # handlers file for verygood.rsyslog
 
 - name: reload rsyslog
-  command: service rsyslog reload
+  service:
+      name=rsyslog
+      state=restarted
+      enabled=yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,9 @@
 ---
 
-- apt: name=rsyslog state=present
-  tags: rsyslog
+- name: install rsyslog
+  package:
+    name=rsyslog
+    state=present
 
 - name: configure rsyslog
   template: src=rsyslog.conf.j2 dest=/etc/rsyslog.conf


### PR DESCRIPTION
Add support for Amazon Linux distro which is used on ElasticBeanstalk hosts